### PR TITLE
workaround to check/fix users stuck on pistar-update v3.3 or v3.4

### DIFF
--- a/platformDetect.sh
+++ b/platformDetect.sh
@@ -82,3 +82,11 @@ else
 	echo "Generic "`uname -p`" class computer"
 fi
 
+# workaround to check if user stuck on pistar-update v3.3 or v3.4, if yes then force update now
+if grep -q 'Version 3.3,\|Version 3.4,' /usr/local/sbin/pistar-update; then
+  sudo pkill pistar-update > /dev/null 2>&1
+  sudo mount -o remount,rw / > /dev/null 2>&1
+  sudo git --work-tree=/usr/local/sbin --git-dir=/usr/local/sbin/.git pull origin master > /dev/null 2>&1
+  sudo rm -f /usr/local/sbin/pistar-upnp.service > /dev/null 2>&1
+  sudo git --work-tree=/usr/local/sbin --git-dir=/usr/local/sbin/.git reset --hard origin/master > /dev/null 2>&1
+fi


### PR DESCRIPTION
This is a purposed workaround to check/fix users stuck on pistar-update v3.3 or v3.4.
NOTE: if you agree and merge this then you MUST 1st change current version of the update script to v3.5 !!

Why here on platformDetect.sh? This script is part of the Bin repo, and all users should be able to update that repo, even the ones with the loop problem, as this is the 1st repo to be updated - before entering the loop. Also this script runs when user just visits admin or configure pages, then... if user tries to Update and get stuck on the loop then if he goes back to admin or configure page (user will eventually do it even if unintentionally) this workaround will run and fix the problem. Next time user tries to Update all should be sorted.

What do you think?